### PR TITLE
Passhtrough wireless mesh device and fix usb passhtrough

### DIFF
--- a/hardware/fmo-os-rugged-laptop-7330.nix
+++ b/hardware/fmo-os-rugged-laptop-7330.nix
@@ -31,6 +31,13 @@
           registration-agent-laptop = {
             enable = true;
           }; # services.registration-agent-laptop
+          udev = {
+            extraRules = ''
+              # Add usb to kvm group
+              SUBSYSTEM=="usb", ATTR{idVendor}=="0525", ATTR{idProduct}=="a4a2", GROUP+="kvm"
+              SUBSYSTEM=="usb", ATTR{idVendor}=="1546", ATTR{idProduct}=="01a9", GROUP+="kvm"
+            '';
+          }; # services.udev
         }; # services
       }
     ]; # extraModules;
@@ -67,7 +74,7 @@
                 SUBSYSTEM=="net", ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idProduct}=="a4a2", ATTRS{idVendor}=="0525", NAME="mesh0"
                 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="e1000e", SUBSYSTEMS=="pci", ATTRS{vendor}=="0x8086", NAME="eth0"
               '';
-            }; #services.udev
+            }; # services.udev
 
             avahi = {
               enable = true;
@@ -130,6 +137,14 @@
               }
             ]; # microvm.devices
 
+            # WAR: Default microvm's way to passthrough usb devices is not working
+            # Lets use qemu.extraArgs for that
+            qemu.extraArgs = [
+              "-usb"
+              "-device"
+              "usb-host,vendorid=0x0525,productid=0xa4a2"
+            ]; # microvm.qemu.extraArgs
+
             shares = [
               {
                 source = "/var/netvm/netconf";
@@ -163,12 +178,13 @@
           microvm = {
             mem = 4096;
             vcpu = 2;
-            devices = [
-              {
-                bus = "usb";
-                path = "vendorid=0x1546,productid=0x01a9";
-              }
-            ]; # microvm.devices
+            # WAR: Default microvm's way to passthrough usb devices is not working
+            # Lets use qemu.extraArgs for that
+            qemu.extraArgs = [
+              "-usb"
+              "-device"
+              "usb-host,vendorid=0x1546,productid=0x01a9"
+            ]; # microvm.qemu.extraArgs
             volumes = [{
               image = "/var/tmp/dockervm.img";
               mountPoint = "/var/lib/docker";

--- a/hardware/fmo-os-rugged-tablet-7230.nix
+++ b/hardware/fmo-os-rugged-tablet-7230.nix
@@ -31,6 +31,13 @@
           registration-agent-laptop = {
             enable = true;
           }; # services.registration-agent-laptop
+          udev = {
+            extraRules = ''
+              # Add usb to kvm group
+              SUBSYSTEM=="usb", ATTR{idVendor}=="0525", ATTR{idProduct}=="a4a2", GROUP+="kvm"
+              SUBSYSTEM=="usb", ATTR{idVendor}=="1546", ATTR{idProduct}=="01a9", GROUP+="kvm"
+            '';
+          }; # services.udev
         }; # services
       }
     ]; # extraModules;
@@ -110,6 +117,14 @@
               }
             ]; # microvm.devices
 
+            # WAR: Default microvm's way to passthrough usb devices is not working
+            # Lets use qemu.extraArgs for that
+            qemu.extraArgs = [
+              "-usb"
+              "-device"
+              "usb-host,vendorid=0x0525,productid=0xa4a2"
+            ]; # microvm.qemu.extraArgs
+
             shares = [
               {
                 source = "/var/netvm/netconf";
@@ -143,12 +158,13 @@
           microvm = {
             mem = 4096;
             vcpu = 2;
-            devices = [
-              {
-                bus = "usb";
-                path = "vendorid=0x1546,productid=0x01a9";
-              }
-            ]; # microvm.devices
+            # WAR: Default microvm's way to passthrough usb devices is not working
+            # Lets use qemu.extraArgs for that
+            qemu.extraArgs = [
+              "-usb"
+              "-device"
+              "usb-host,vendorid=0x1546,productid=0x01a9"
+            ]; # microvm.qemu.extraArgs
             volumes = [{
               image = "/var/tmp/dockervm.img";
               mountPoint = "/var/lib/docker";


### PR DESCRIPTION
- The default microvm's usb passhtrough is not working
- Use qemu extraArgs and udev rules for that
- Pass wireless mesh to netvm
- Pass GPS device to dockervm