### PR TITLE
Add new targets for public build

### DIFF
--- a/config-processor-hardware.nix
+++ b/config-processor-hardware.nix
@@ -13,9 +13,15 @@
   sysconf,
 }:
 let
-  name = sysconf.name;
+  updateAttrs = (import ./utils/updateAttrs.nix).updateAttrs;
+
+  targetconf = if lib.hasAttr "extend" sysconf
+               then updateAttrs false (import (lib.path.append ./hardware sysconf.extend) ).sysconf sysconf
+               else sysconf;
+
+  name = targetconf.name;
   system = "x86_64-linux";
-  vms = sysconf.vms;
+  vms = targetconf.vms;
 
   importvm = vmconf: (import ./modules/virtualization/microvm/vm.nix {inherit ghafOS vmconf;});
   enablevm = vm: {
@@ -24,8 +30,8 @@ let
       extraModules = vm.extraModules;
     };
   };
-  addSystemPackages = {pkgs, ...}: {environment.systemPackages = map (app: pkgs.${app}) sysconf.systemPackages;};
-  addCustomLaunchers = (import ./utils/launchers.nix {inherit sysconf;});
+  addSystemPackages = {pkgs, ...}: {environment.systemPackages = map (app: pkgs.${app}) targetconf.systemPackages;};
+  addCustomLaunchers = (import ./utils/launchers.nix {sysconf = targetconf;});
 
   formatModule = nixos-generators.nixosModules.raw-efi;
   target = variant: extraModules: let
@@ -74,7 +80,7 @@ let
         ++ (import "${ghafOS}/modules/module-list.nix")
         ++ (import ./modules/fmo-module-list.nix)
         ++ extraModules
-        ++ (if lib.hasAttr "extraModules" sysconf then sysconf.extraModules else []);
+        ++ (if lib.hasAttr "extraModules" targetconf then targetconf.extraModules else []);
     };
   in {
     inherit hostConfiguration;

--- a/flake.nix
+++ b/flake.nix
@@ -73,9 +73,12 @@
     ]
     ++ map generateHwConfig [
       (import ./hardware/fmo-os-rugged-laptop-7330.nix)
+      (import ./hardware/fmo-os-rugged-laptop-7330-public.nix)
       (import ./hardware/fmo-os-rugged-tablet-7230.nix)
+      (import ./hardware/fmo-os-rugged-tablet-7230-public.nix)
     ]
     ++ map generateInstConfig [
       (import ./installers/fmo-os-installer.nix)
+      (import ./installers/fmo-os-installer-public.nix)
     ]);
 }

--- a/hardware/fmo-os-rugged-laptop-7330-public.nix
+++ b/hardware/fmo-os-rugged-laptop-7330-public.nix
@@ -1,0 +1,30 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# fmo-os-rugged-laptop-7330-public -target
+{
+  sysconf = {
+    extend = "./fmo-os-rugged-laptop-7330.nix";
+    name = "fmo-os-rugged-laptop-7330-public";
+    extraModules = [
+    {
+      services = {
+        registration-agent-laptop = {
+          enable = false;
+        }; # services.registration-agent-laptop
+      }; # services
+    }]; # extraModules;
+    vms = {
+      dockervm = {
+        extraModules = [
+        {
+          services = {
+            registration-agent-laptop = {
+              enable = false;
+            }; # services.registration-agent-laptop
+          }; # services
+        }]; # extraModules
+      }; # dockervm
+    }; # vms
+  }; # sysconf
+}

--- a/hardware/fmo-os-rugged-tablet-7230-public.nix
+++ b/hardware/fmo-os-rugged-tablet-7230-public.nix
@@ -1,0 +1,30 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# fmo-os-disabled-for-public -target
+{
+  sysconf = {
+    extend = "./fmo-os-rugged-tablet-7230.nix";
+    name = "fmo-os-rugged-tablet-7230-public";
+    extraModules = [
+    {
+      services = {
+        registration-agent-laptop = {
+          enable = false;
+        }; # services.registration-agent-laptop
+      }; # services
+    }]; # extraModules;
+    vms = {
+      dockervm = {
+        extraModules = [
+        {
+          services = {
+            registration-agent-laptop = {
+              enable = false;
+            }; # services.registration-agent-laptop
+          }; # services
+        }]; # extraModules
+      }; # dockervm
+    }; # vms
+  }; # sysconf
+}

--- a/installers/fmo-os-installer-public.nix
+++ b/installers/fmo-os-installer-public.nix
@@ -1,0 +1,37 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# FMO-OS general installer includes images for Rugged tablet and laptop without registration agent
+#
+{
+  # system and host description
+  sysconf = {
+    extend = "./fmo-os-installer.nix";
+    name = "fmo-os-installer-public";
+    extraModules = [
+      {
+        services = {
+          registration-agent-laptop ={
+            enable = false;
+          }; # services.registration-agent-laptop
+        }; # services
+      }
+    ]; # extraModules
+
+    installer = {
+      name = "pterm-installer";
+      enable = true;
+      run_on_boot = true;
+      welcome_msg = "Welcome to FMO-OS installer";
+      mount_path = "/home/ghaf/root";
+      custom_script_path = "";
+      custom_script_env_path = [];
+    }; # installer
+
+    # OS to include
+    oss = [
+      "fmo-os-rugged-laptop-7330-public"
+      "fmo-os-rugged-tablet-7230-public"
+    ]; # oss
+  }; # system
+}

--- a/modules/pterm-installer/default.nix
+++ b/modules/pterm-installer/default.nix
@@ -58,7 +58,7 @@ in
       installerGoScript = pkgs.buildGo120Module {
         name = "ghaf-installer";
         src = builtins.fetchGit {
-          url = "git@github.com:tiiuae/FMO-OS-Installer.git";
+          url = "https://github.com/tiiuae/FMO-OS-Installer.git";
           rev = "4b05908e816d6ee22409c74b22ec8e8189b2cf8c";
           ref = "refs/heads/main";
         };

--- a/utils/updateAttrs.nix
+++ b/utils/updateAttrs.nix
@@ -1,0 +1,53 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+rec {
+  unique = builtins.foldl' (acc: e:
+                if builtins.elem e acc then acc else acc ++ [ e ]) [];
+
+  concatOrOverwriteList = (
+    # Bool flag to choose to overwrite rhs list wih lhs or concatenate both lists
+    # true - overwrite
+    # false - concatenate
+    pred:
+    # Left attribute set of the merge.
+    lhs:
+    # Right attribute set of the merge.
+    rhs:
+    if pred
+    then
+      lhs
+    else
+      unique (builtins.concatLists [lhs rhs]));
+
+  updateAttrs =
+    # Bool flag to choose to overwrite rhs list wih lhs or concatenate both lists
+    # true - overwrite
+    # false - concatenate
+    overwriteList:
+    # Left attribute set of the merge.
+    lhs:
+    # Right attribute set of the merge.
+    rhs:
+    let f = (attrPath: builtins.zipAttrsWith (n: values:
+      let here = attrPath ++ [n]; in
+      if builtins.length values == 1
+      then
+        builtins.head values
+      else
+        if (builtins.isList (builtins.elemAt values 1) && builtins.isList (builtins.head values))
+        then
+          if builtins.isAttrs (builtins.head (builtins.concatLists [(builtins.head values) (builtins.elemAt values 1)]))
+          then
+            [ (f [] (builtins.concatLists [(builtins.head values) (builtins.elemAt values 1)])) ]
+          else
+            concatOrOverwriteList overwriteList (builtins.head values) (builtins.elemAt values 1)
+        else
+          if (builtins.isAttrs (builtins.elemAt values 1) && builtins.isAttrs (builtins.head values))
+          then
+            f here values
+          else
+            builtins.head values
+      ));
+    in
+      f [] [rhs lhs];
+}


### PR DESCRIPTION
- Add "updateAttrs" as custom update attributes and lists method, that allow to concatenate lists instead of overwriting them (like lib.recursiveUpdate)
- Add public targets which has a "extend" that indicates the target that they are based on.
- Reconfigure "config-processor-hardware" and "config-processor-installer" for new public targets
