### PR TITLE
Disable docs build target

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,20 +49,20 @@
       (flake-utils.lib.eachSystem systems (system: let
         pkgs = nixpkgs.legacyPackages.${system};
       in {
-        packages.doc = pkgs.callPackage "${ghafOS}/docs" {
-          revision = lib.version;
-          options = let
-            cfg = nixpkgs.lib.nixosSystem {
-              inherit system;
-              modules =
-                lib.ghaf.modules
-                ++ [
-                  microvm.nixosModules.host 
-                ];
-            };
-          in
-            cfg.options;
-        };
+        # packages.doc = pkgs.callPackage "${ghafOS}/docs" {
+        #   revision = lib.version;
+        #   options = let
+        #     cfg = nixpkgs.lib.nixosSystem {
+        #       inherit system;
+        #       modules =
+        #         lib.ghaf.modules
+        #         ++ [
+        #           microvm.nixosModules.host
+        #         ];
+        #     };
+        #   in
+        #     cfg.options;
+        # };
 
         hydraJobs = {
           inherit (self) packages;


### PR DESCRIPTION
Disable docs build target until it is refactored on Ghaf repository.
Currently, it causes flake check to fail, because it forces 'aarch64-linux'
target enabled.