### PR TITLE
Configure public Hydra targets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,16 @@
         pkgs = nixpkgs.legacyPackages.${system};
       in {
         hydraJobs = {
-          inherit (self) packages;
+          packages = {
+            x86_64-linux = {
+              fmo-os-installer-public-debug = self.packages.x86_64-linux.fmo-os-installer-public-debug;
+              fmo-os-installer-public-release = self.packages.x86_64-linux.fmo-os-installer-public-release;
+              fmo-os-rugged-laptop-7330-public-debug = self.packages.x86_64-linux.fmo-os-rugged-laptop-7330-public-debug;
+              fmo-os-rugged-laptop-7330-public-release = self.packages.x86_64-linux.fmo-os-rugged-laptop-7330-public-release;
+              fmo-os-rugged-tablet-7230-public-debug = self.packages.x86_64-linux.fmo-os-rugged-tablet-7230-public-debug;
+              fmo-os-rugged-tablet-7230-public-release = self.packages.x86_64-linux.fmo-os-rugged-tablet-7230-public-release;
+            };
+          };
         };
 
         formatter = pkgs.alejandra;


### PR DESCRIPTION
Hardcode public Hydra build targets as a temporary fix, until
automatic target generation is completed.