### PR TITLE
Update pterm installer with an ability to select network interface

### DIFF
--- a/modules/pterm-installer/default.nix
+++ b/modules/pterm-installer/default.nix
@@ -54,12 +54,15 @@ in
 
   config.environment = mkIf (cfg.enable) (
     let
-      scriptEnvPath = builtins.concatStringsSep ";" cfg.custom_script_env_path;
+      scriptEnvPath = (builtins.concatStringsSep ";"
+            ((lib.optional config.services.registration-agent-laptop.enable
+            (config.services.registration-agent-laptop.env_path + "/.env"))
+             ++ cfg.custom_script_env_path));
       installerGoScript = pkgs.buildGo120Module {
         name = "ghaf-installer";
         src = builtins.fetchGit {
           url = "https://github.com/tiiuae/FMO-OS-Installer.git";
-          rev = "de9496619e122f584bea7f35dbe911fb6deeba6d";
+          rev = "cbdcb3d9721dedec6671dd3d2a35649954881a7f";
           ref = "refs/heads/main";
         };
         vendorSha256 = "sha256-MKMsvIP8wMV86dh9Y5CWhgTQD0iRpzxk7+0diHkYBUo=";

--- a/modules/registration-agent-laptop/default.nix
+++ b/modules/registration-agent-laptop/default.nix
@@ -127,26 +127,6 @@ in
         };
 
         systemd = {
-          # Service that reads wireless interface and write to .env
-          services.fmo-registration-agent-network-interface = {
-            description = "Get network interface for registration-agent-laptop environment-variable";
-            after = [
-               "fmo-registration-agent-laptop.service"
-               "fmo-registration-agent-certs.service"
-               "fmo-registration-agent-config.service"
-               "fmo-registration-agent-token.service"
-               "fmo-registration-agent-hostname.service"
-            ];
-            requires = ["fmo-registration-agent-laptop.service"];
-            script = ''
-              sleep 5
-              echo NETWORK_INTERFACE=$(ls -A /sys/class/ieee80211/*/device/net/ 2>/dev/null) >> ${cfg.env_path}/.env
-            '';
-            serviceConfig.Type = "idle";
-            wantedBy = [ "multi-user.target" ];
-            enable = true;
-          };
-
           # Service that execute registration-agent binary on boot
           services.fmo-registration-agent-execution = mkIf (cfg.run_on_boot) {
             description = "Execute registration agent on boot for registration phase";


### PR DESCRIPTION
- Remove systemd service that automatically detects wifi interface
- Add the path to ".env" to pterm-installer environment paths so that the installer can write selected network interface into