### PR TITLE
Fix a priority error in selecting graphic

### DIFF
--- a/modules/profiles/applications.nix
+++ b/modules/profiles/applications.nix
@@ -23,7 +23,7 @@ in
     };
 
     config.ghaf.graphics = mkIf cfg.enable {
-      weston.enable = lib.mkDefault (cfg.compositor == "weston");
+      weston.enable = lib.mkForce (cfg.compositor == "weston");
       sway.enable = cfg.compositor == "sway";
       app-launchers.enableAppLaunchers = true;
     };


### PR DESCRIPTION
- The fmo graphic configs does not overwrite upstream config
- Use lib.mkForce instead of lib.mkDefault