### PR TITLE
Sway - bind applications to different workspace

### DIFF
--- a/modules/graphics/sway/config
+++ b/modules/graphics/sway/config
@@ -191,6 +191,11 @@ include /etc/sway/config.d/*
 # screenshots
 bindsym $mod+c exec grim  -g "$(slurp)" /tmp/$(date +'%H:%M:%S.png')
 
+# bind app with workspace 
+assign [app_id="chromium-browser"] workspace number 1
+assign [app_id="foot"] workspace number 2
+
+# start with sway
 exec dbus-sway-environment
 exec configure-gtk
 exec_always nwg-panel


### PR DESCRIPTION
- Assign web browser (chromium) to workspace 1
- Assign terminal (foot) to workspace 2
- Keep it as hardcoded because there are not many applications to make the config comlicated