### PR TITLE
Allow import from derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,10 @@
     ];
   };
 
+  nixConfig = {
+    allow-import-from-derivation = true;
+  };
+
   inputs = rec {
     ghafOS.url = "github:tiiuae/ghaf";
   };


### PR DESCRIPTION
If the `allow-import-from-derivation` option is not set/false, `nix flake check` will fail. 
To fix, set `allow-import-from-derivation`  option enabled directly in the flake.