### PR TITLE
Fix fmo-psk-distribution service

### DIFF
--- a/hardware/fmo-os-rugged-tablet-7230.nix
+++ b/hardware/fmo-os-rugged-tablet-7230.nix
@@ -32,6 +32,9 @@
         boot.initrd.availableKernelModules = [ "nvme" "ahci" ];
 
         services = {
+          fmo-psk-distribution-service-host = {
+              enable = true;
+          }; # services.fmo-psk-distribution-service-host
           registration-agent-laptop = {
             enable = true;
           }; # services.registration-agent-laptop

--- a/modules/fmo-psk-distribution-vm/default.nix
+++ b/modules/fmo-psk-distribution-vm/default.nix
@@ -7,18 +7,6 @@ let
 in {
   options.services.fmo-psk-distribution-service-vm = {
     enable   = mkEnableOption "fmo-psk-distribution-service-vm";
-
-    ipaddress-path = mkOption {
-      type = types.str;
-      description = "Path to ipaddress file for dynamic use";
-      default = "";
-    };
-
-    ipaddress = mkOption {
-      type = types.str;
-      description = "Static IP address to use instead for dynamic from file";
-      default = "";
-    };
   };
 
   config = mkIf cfg.enable {


### PR DESCRIPTION
- Enable fmo-psk-distribution on host tablet
- Clean up unused code in psk-distribution-vm