### PR TITLE
Release 1.0.0b fixes

### DIFF
--- a/hardware/fmo-os-rugged-laptop-7330.nix
+++ b/hardware/fmo-os-rugged-laptop-7330.nix
@@ -63,7 +63,10 @@
         {
           users.users."ghaf".extraGroups = ["networkmanager"];
           networking = {
-            nat.enable = true;
+            nat = {
+              enable = true;
+              internalIPs = [ "192.168.101.0/24" ];
+            }; # networking.nat
             wireless = {
               enable = true;
             };

--- a/hardware/fmo-os-rugged-laptop-7330.nix
+++ b/hardware/fmo-os-rugged-laptop-7330.nix
@@ -110,15 +110,33 @@
                 }
                 {
                   dip = "192.168.101.11";
+                  dport = "4222";
+                  sport = "4222";
+                  proto = "udp";
+                }
+                {
+                  dip = "192.168.101.11";
                   dport = "7222";
                   sport = "7222";
                   proto = "tcp";
                 }
                 {
                   dip = "192.168.101.11";
+                  dport = "7222";
+                  sport = "7222";
+                  proto = "udp";
+                }
+                {
+                  dip = "192.168.101.11";
                   dport = "4223";
                   sport = "4223";
                   proto = "tcp";
+                }
+                {
+                  dip = "192.168.101.11";
+                  dport = "4223";
+                  sport = "4223";
+                  proto = "udp";
                 }
               ];
             }; # services.portforwarding-service;

--- a/hardware/fmo-os-rugged-tablet-7230.nix
+++ b/hardware/fmo-os-rugged-tablet-7230.nix
@@ -63,7 +63,10 @@
         {
           users.users."ghaf".extraGroups = ["networkmanager"];
           networking = {
-            nat.enable = true;
+            nat = {
+              enable = true;
+              internalIPs = [ "192.168.101.0/24" ];
+            }; # networking.nat
             wireless = {
               enable = true;
             };

--- a/hardware/fmo-os-rugged-tablet-7230.nix
+++ b/hardware/fmo-os-rugged-tablet-7230.nix
@@ -110,15 +110,33 @@
                 }
                 {
                   dip = "192.168.101.11";
+                  dport = "4222";
+                  sport = "4222";
+                  proto = "udp";
+                }
+                {
+                  dip = "192.168.101.11";
                   dport = "7222";
                   sport = "7222";
                   proto = "tcp";
                 }
                 {
                   dip = "192.168.101.11";
+                  dport = "7222";
+                  sport = "7222";
+                  proto = "udp";
+                }
+                {
+                  dip = "192.168.101.11";
                   dport = "4223";
                   sport = "4223";
                   proto = "tcp";
+                }
+                {
+                  dip = "192.168.101.11";
+                  dport = "4223";
+                  sport = "4223";
+                  proto = "udp";
                 }
               ];
             }; # services.portforwarding-service;


### PR DESCRIPTION
- Fix NAT rules to provide dockerapps access through netvm ip
- Add port-forwarding rules to forward UDP traffic also