### PR TITLE
Partially support copy/paste feature

### DIFF
--- a/modules/app-launchers/default.nix
+++ b/modules/app-launchers/default.nix
@@ -17,10 +17,10 @@
           package = [pkgs.chromium];
         };
         terminal = {
-          name = "Foot";
-          path = "${pkgs.foot}/bin/foot ${extraArgs}";
-          icon = "${pkgs.foot}/share/icons/hicolor/48x48/apps/foot.png";
-          package = [pkgs.foot];
+          name = "Terminal";
+          path = "${pkgs.terminator}/bin/terminator ${extraArgs}";
+          icon = "${pkgs.terminator}/share/icons/hicolor/48x48/apps/terminator.png";
+          package = [pkgs.terminator];
         };
         nmLauncher = {
           name = "nmLauncher";

--- a/modules/custom-packages/default.nix
+++ b/modules/custom-packages/default.nix
@@ -13,5 +13,6 @@ _: {
     (import ./registration-agent)
     (import ./squeekboard)
     (import ./sway-scripts)
+    (import ./terminator)
   ];
 }

--- a/modules/custom-packages/terminator/config.patch
+++ b/modules/custom-packages/terminator/config.patch
@@ -1,0 +1,22 @@
+diff --git a/terminatorlib/config.py b/terminatorlib/config.py
+index 008d1cfa..c2be42cf 100644
+--- a/terminatorlib/config.py
++++ b/terminatorlib/config.py
+@@ -230,7 +230,7 @@ DEFAULTS = {
+                 'cursor_color_default'  : True,
+                 'term'                  : 'xterm-256color',
+                 'colorterm'             : 'truecolor',
+-                'font'                  : 'Mono 10',
++                'font'                  : 'Hack 12',
+                 'foreground_color'      : '#aaaaaa',
+                 'show_titlebar'         : True,
+                 'scrollbar_position'    : "right",
+@@ -248,7 +248,7 @@ DEFAULTS = {
+                 'login_shell'           : False,
+                 'use_custom_command'    : False,
+                 'custom_command'        : '',
+-                'use_system_font'       : True,
++                'use_system_font'       : False,
+                 'use_theme_colors'      : False,
+                 'bold_is_bright'        : False,
+                 'cell_height'           : 1.0,

--- a/modules/custom-packages/terminator/default.nix
+++ b/modules/custom-packages/terminator/default.nix
@@ -1,0 +1,7 @@
+# Copyright 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+(final: _prev: {
+  terminator = _prev.terminator.overrideAttrs (old : {
+      patches = [ ./config.patch ];
+  });
+})

--- a/modules/graphics/fonts.nix
+++ b/modules/graphics/fonts.nix
@@ -13,6 +13,7 @@ in {
       lib.lists.optionals sway.enable [
         font-awesome_5
         font-awesome
+        hack-font
       ];
   };
 }

--- a/modules/graphics/sway/config
+++ b/modules/graphics/sway/config
@@ -9,7 +9,7 @@ set $down j
 set $up k
 set $right l
 # Your preferred terminal emulator
-set $term foot
+set $term terminator
 # Your preferred application launcher
 # Note: pass the final command to swaymsg so that the resulting window can be opened
 # on the original workspace that the command was run on.
@@ -198,5 +198,6 @@ bindsym $mod+c exec grim  -g "$(slurp)" /tmp/$(date +'%H:%M:%S.png')
 # start with sway
 exec dbus-sway-environment
 exec configure-gtk
+exec wl-paste -t text --watch clipman store
 exec_always nwg-panel
 exec_always lisgd

--- a/modules/graphics/sway/sway.nix
+++ b/modules/graphics/sway/sway.nix
@@ -73,6 +73,7 @@ in
       grim # screenshot functionality
       slurp # screenshot functionality
       wl-clipboard # wl-copy and wl-paste for copy/paste from stdin / stdout
+      clipman
       mako # notification system developed by swaywm maintainer
       wdisplays # tool to configure displays
       wl-mirror # mirror displays
@@ -108,7 +109,7 @@ in
     enable = true;
     wrapperFeatures.gtk = true;
     extraPackages = with pkgs; [
-      foot
+      terminator
       xwayland
       mako
       kanshi


### PR DESCRIPTION
- Sway does not support global context menu, therefore, it depends on individual app
- Use "terminator" in replacement of "foot" for context menu support
- Add config for font in "terminator"
- Add "clipman" as clipboard manager, allow retain the clipboard even after the copied source exits