### PR TITLE
CICD: Remove absoulute path in upload actions

### DIFF
--- a/.github/actions/build-action/entrypoint.sh
+++ b/.github/actions/build-action/entrypoint.sh
@@ -10,7 +10,7 @@ RA_TOKEN=$3
 SSH_DIR="/root/.ssh/"
 RESULT_DIR="result/iso/"
 RESULT_NAME="nixos.iso"
-RESULT_COPY_DIR="./result_to_upload/"
+RESULT_COPY_DIR="./"
 SYS_USER_NAME="root"
 
 err_print() {

--- a/.github/actions/upload-action-harbor/upload.sh
+++ b/.github/actions/upload-action-harbor/upload.sh
@@ -14,6 +14,8 @@ err_exit() {
   exit "$rc"
 }
 
+cd $GITHUB_WORKSPACE
+
 echo "::group::Input validation"
 
 [ ! "$HARBOR_URL" ] && err_exit 1 "HARBOR_URL undefined"
@@ -41,7 +43,7 @@ for input in $INPUT_PATHS; do
 
   UPLOAD_DIR=$SOURCE_DIR
   echo "oras push "$HARBOR_URL/$DEST_DIR:$TAG" $UPLOAD_DIR"
-  oras push --disable-path-validation "$HARBOR_URL/$DEST_DIR:$TAG" $UPLOAD_DIR
+  oras push "$HARBOR_URL/$DEST_DIR:$TAG" $UPLOAD_DIR
 done
 
 echo "::endgroup::"

--- a/.github/actions/upload-action-jfrog/upload.sh
+++ b/.github/actions/upload-action-jfrog/upload.sh
@@ -14,6 +14,8 @@ err_exit() {
   exit "$rc"
 }
 
+cd $GITHUB_WORKSPACE
+
 echo "::group::Input validation"
 
 [ ! "$JFROG_URL" ] && err_exit 1 "JFROG_URL undefined"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           JFROG_TOKEN: ${{ secrets.JFROG_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}
           input-paths:  |
-            ${{ github.workspace }}/${{ steps.build.outputs.outimg }}:tii-fmo-os/releases/FMO-OS_inst_${{ steps.tag.outputs.TAG_VERSION }}.iso
+            ${{ steps.build.outputs.outimg }}:tii-fmo-os/releases/FMO-OS_inst_${{ steps.tag.outputs.TAG_VERSION }}.iso
       - name: Push to Harbor artifactory
         uses: ./.github/actions/upload-action-harbor
         with:
@@ -64,5 +64,5 @@ jobs:
           HARBOR_TOKEN: ${{ secrets.HARBOR_TOKEN }}
           HARBOR_URL: ${{ secrets.HARBOR_URL }}
           input-paths:  |
-            ${{ github.workspace }}/${{ steps.build.outputs.outimg }}:fmo/pmc-installer:${{ steps.tag.outputs.TAG_VERSION }}
+            ${{ steps.build.outputs.outimg }}:fmo/pmc-installer:${{ steps.tag.outputs.TAG_VERSION }}
 


### PR DESCRIPTION
- oras cannot download artifacts uploaded with absolute path
- remove absolute path and use relative