### PR TITLE
FMO-35: FMO-DCI service needs to read docker container repository URL from file

### DIFF
--- a/hardware/fmo-os-rugged-laptop-7330.nix
+++ b/hardware/fmo-os-rugged-laptop-7330.nix
@@ -256,6 +256,8 @@
               backup-path = "/var/lib/fogdata/docker-compose.yml.backup";
               pat-path = "/var/lib/fogdata/PAT.pat";
               preloaded-images = "tii-offline-map-data-loader.tar.gz";
+              docker-url = "cr.airoplatform.com";
+              docker-url-path = "/var/lib/fogdata/cr.url";
             }; # services.fmo-dci
             avahi = {
               enable = true;

--- a/hardware/fmo-os-rugged-tablet-7230.nix
+++ b/hardware/fmo-os-rugged-tablet-7230.nix
@@ -236,6 +236,8 @@
               backup-path = "/var/lib/fogdata/docker-compose.yml.backup";
               pat-path = "/var/lib/fogdata/PAT.pat";
               preloaded-images = "tii-offline-map-data-loader.tar.gz";
+              docker-url = "cr.airoplatform.com";
+              docker-url-path = "/var/lib/fogdata/cr.url";
             }; # services.fmo-dci
             avahi = {
               enable = true;

--- a/modules/fmo-dci-service/default.nix
+++ b/modules/fmo-dci-service/default.nix
@@ -32,6 +32,11 @@ in {
     docker-url = mkOption {
       type = types.str;
       default = "";
+      description = "Default container repository URL to use";
+    };
+    docker-url-path = mkOption {
+      type = types.str;
+      default = "";
       description = "Path to docker url file";
     };
   };
@@ -52,6 +57,11 @@ in {
         BCPPATH=$(echo ${cfg.backup-path})
         PRELOAD_PATH=$(echo ${preload_path})
         DOCKER_URL=$(echo ${cfg.docker-url})
+        DOCKER_URL_PATH=$(echo ${cfg.docker-url-path})
+
+        if [ -e "$DOCKER_URL_PATH" ]; then
+          DOCKER_URL=$(cat $DOCKER_URL_PATH)
+        fi
 
         # Check if the update file exists
         if [ -e "$UPDPATH" ]; then
@@ -72,10 +82,6 @@ in {
             echo "Update file does not exist. No operations performed"
         fi
 
-        if [ -z "$DOCKER_URL" ]; then
-          DOCKER_URL="cr.airoplatform.com"
-        fi
-        
         echo "Login $DOCKER_URL"
         echo $PAT | ${pkgs.docker}/bin/docker login $DOCKER_URL -u $USR --password-stdin || echo "login to $DOCKER_URL failed continue as is"
 


### PR DESCRIPTION
- Use default CR URL if file does not exist
- Use CR URL from file if it exists