### PR TITLE
fix battery indicator issue on laptop

### DIFF
--- a/modules/desktop/graphics/sway/nwg-panel/default.nix
+++ b/modules/desktop/graphics/sway/nwg-panel/default.nix
@@ -113,6 +113,7 @@
 in {
 
   config =  lib.mkIf cfg.enable {
+    services.upower.enable = true;
     environment.etc."xdg/nwg-panel/config" = {
       text = panelConfig;
       # The UNIX file mode bits


### PR DESCRIPTION
- Fix an issue that the indicator show 0% battery
- Add upower package as nwg-panel uses it for devices with 2+ batteries