### PR TITLE
FMO-53: Add qemu machine as q35 to fix wifi error on laptop

### DIFF
--- a/modules/virtualization/microvm/vm.nix
+++ b/modules/virtualization/microvm/vm.nix
@@ -33,6 +33,7 @@
         nixpkgs.hostPlatform.system = configHost.nixpkgs.hostPlatform.system;
 
         microvm.hypervisor = "qemu";
+        microvm.qemu.machine = "q35";
 
         networking = {
           enableIPv6 = false;
@@ -53,8 +54,6 @@
 
         microvm.shares = [
           # Use host's /nix/store to reduce size of the image
-          # WAR: to enable -M q35 option need to share any fs or pcie devices
-          # WAR: otherwise machine is not able to start, why?
           {
             tag = "ro-store";
             source = "/nix/store";


### PR DESCRIPTION
- Fix wifi interface not found on laptop target
- Set qemu machine to q35