### PR TITLE
FMO-54: Create symlink to installer system

### DIFF
--- a/config-processor-installers.nix
+++ b/config-processor-installers.nix
@@ -71,7 +71,7 @@ let
           })
 
           # Configs for installation
-          {
+          ({lib, ...}: {
             installer.includeOSS = {
               enable = lib.mkDefault true;
               oss_list_fname = lib.mkDefault "${oss_list_name}";
@@ -79,7 +79,8 @@ let
                 name = "${os}-${variant}";
                 image = self.nixosConfigurations.${name};}) oss;
             };
-          }
+            services.registration-agent-laptop.createAllConfig = lib.mkForce false;
+          })
 
           # Installer app
           {

--- a/modules/fmo-services/registration-agent-laptop/default.nix
+++ b/modules/fmo-services/registration-agent-laptop/default.nix
@@ -13,6 +13,7 @@ in
   with lib; {
     options.services.registration-agent-laptop = {
       enable = mkEnableOption "Install and setup registration-agent on system";
+      createAllConfig = mkEnableOption "Create all config folders";
 
       run_on_boot = mkOption {
         description = mdDoc ''
@@ -66,12 +67,13 @@ in
     };
 
     config =  mkIf (cfg.enable) {
+        services.registration-agent-laptop.createAllConfig = true;
         environment.systemPackages = [ pkgs.registration-agent-laptop];
 
         services.writeToFile = {
           enable = true;
-          enabledFiles = [
-            "fmo-registration-agent-laptop"
+          enabledFiles = ["fmo-registration-agent-laptop"]
+            ++ lib.optionals cfg.createAllConfig [
             "fmo-registration-agent-certs"
             "fmo-registration-agent-config"
             "fmo-registration-agent-hostname"

--- a/modules/installers/pterm-installer/default.nix
+++ b/modules/installers/pterm-installer/default.nix
@@ -75,7 +75,7 @@ in
         name = "ghaf-installer";
         src = builtins.fetchGit {
           url = "https://github.com/tiiuae/FMO-OS-Installer.git";
-          rev = "0a12c7f3288f7019adc7781310f02f47f61444f1";
+          rev = "a7db48bd46841b1c94babc80946626f4cc8416f7";
           ref = "refs/heads/main";
         };
         vendorHash = "sha256-CFFSaURE4lJZS6E8XT6KcRv4hk6wO059lzD1V2wfZgI=";


### PR DESCRIPTION
- Add an option for installer to disable creation of some registration-agent folders, let pterm-installer do that
- Modify env in the installer
- Add symlink path for pterm-installer to create the symlink
- Update pterm-installer with above features
- In the installer system, registration agent runs as if it is running dockervm, with (env=/var/lib/fogdata)