### PR TITLE
FMO-52: Systemd.networkd and NetworkManager are not able to work together

### DIFF
--- a/hardware/fmo-os-rugged-laptop-7330.nix
+++ b/hardware/fmo-os-rugged-laptop-7330.nix
@@ -66,6 +66,7 @@
         {
           users.users."ghaf".extraGroups = ["networkmanager"];
           networking = {
+            useDHCP = false;
             nat = {
               enable = true;
               internalIPs = [ "192.168.101.0/24" ];

--- a/hardware/fmo-os-rugged-tablet-7230.nix
+++ b/hardware/fmo-os-rugged-tablet-7230.nix
@@ -66,6 +66,7 @@
         {
           users.users."ghaf".extraGroups = ["networkmanager"];
           networking = {
+            useDHCP = false;
             nat = {
               enable = true;
               internalIPs = [ "192.168.101.0/24" ];


### PR DESCRIPTION
* For netwm we need to disable systemd.networkd dhcp to keep that manageable only with NetworkManager