### PR TITLE
FMO-66: Update installer with filtered partition

### DIFF
--- a/modules/installers/pterm-installer/default.nix
+++ b/modules/installers/pterm-installer/default.nix
@@ -75,7 +75,7 @@ in
         name = "ghaf-installer";
         src = builtins.fetchGit {
           url = "https://github.com/tiiuae/FMO-OS-Installer.git";
-          rev = "a7db48bd46841b1c94babc80946626f4cc8416f7";
+          rev = "67377b4cb9a1b02d594cf2d7a0c3157e41e30e90";
           ref = "refs/heads/main";
         };
         vendorHash = "sha256-CFFSaURE4lJZS6E8XT6KcRv4hk6wO059lzD1V2wfZgI=";


### PR DESCRIPTION
- Keep only internal drive
- Fix hardcoded order of exit screen