### PR TITLE
FMO-21: Persistence storage for VMs, and file transfer

### DIFF
--- a/hardware/fmo-os-rugged-laptop-7330.nix
+++ b/hardware/fmo-os-rugged-laptop-7330.nix
@@ -211,7 +211,31 @@
               "usb-host,vendorid=0x0525,productid=0xa4a2"
             ]; # microvm.qemu.extraArgs
 
+            volumes = [
+              {
+                image = "/var/tmp/netvm_internal.img";
+                mountPoint = "/var/lib/internal";
+                size = 10240;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+            ];# microvm.volumes
+
             shares = [
+              {
+                source = "/var/vms_shares/common";
+                mountPoint = "/var/vms_share/common";
+                tag = "common_share_netvm";
+                proto = "virtiofs";
+                socket = "common_share_netvm.sock";
+              }
+              {
+                source = "/var/vms_shares/netvm";
+                mountPoint = "/var/vms_share/host";
+                tag = "netvm_share";
+                proto = "virtiofs";
+                socket = "netvm_share.sock";
+              }
               {
                 source = "/var/netvm/netconf";
                 mountPoint = "/etc/NetworkManager/system-connections";
@@ -258,14 +282,37 @@
               "-device"
               "usb-host,vendorid=0x1546,productid=0x01a9"
             ]; # microvm.qemu.extraArgs
-            volumes = [{
-              image = "/var/tmp/dockervm.img";
-              mountPoint = "/var/lib/docker";
-              size = 51200;
-              autoCreate = true;
-              fsType = "ext4";
-            }];# microvm.volumes
+            volumes = [
+              {
+                image = "/var/tmp/dockervm_internal.img";
+                mountPoint = "/var/lib/internal";
+                size = 10240;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+              {
+                image = "/var/tmp/dockervm.img";
+                mountPoint = "/var/lib/docker";
+                size = 51200;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+            ];# microvm.volumes
             shares = [
+              {
+                source = "/var/vms_shares/common";
+                mountPoint = "/var/vms_share/common";
+                tag = "common_share_dockervm";
+                proto = "virtiofs";
+                socket = "common_share_dockervm.sock";
+              }
+              {
+                source = "/var/vms_shares/dockervm";
+                mountPoint = "/var/vms_share/host";
+                tag = "dockervm_share";
+                proto = "virtiofs";
+                socket = "dockervm_share.sock";
+              }
               {
                 source = "/var/fogdata";
                 mountPoint = "/var/lib/fogdata";

--- a/hardware/fmo-os-rugged-tablet-7230.nix
+++ b/hardware/fmo-os-rugged-tablet-7230.nix
@@ -191,7 +191,31 @@
               "usb-host,vendorid=0x0525,productid=0xa4a2"
             ]; # microvm.qemu.extraArgs
 
+            volumes = [
+              {
+                image = "/var/tmp/netvm_internal.img";
+                mountPoint = "/var/lib/internal";
+                size = 10240;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+            ];# microvm.volumes
+
             shares = [
+              {
+                source = "/var/vms_shares/common";
+                mountPoint = "/var/vms_share/common";
+                tag = "common_share_netvm";
+                proto = "virtiofs";
+                socket = "common_share_netvm.sock";
+              }
+              {
+                source = "/var/vms_shares/netvm";
+                mountPoint = "/var/vms_share/host";
+                tag = "netvm_share";
+                proto = "virtiofs";
+                socket = "netvm_share.sock";
+              }
               {
                 source = "/var/netvm/netconf";
                 mountPoint = "/etc/NetworkManager/system-connections";
@@ -238,14 +262,37 @@
               "-device"
               "usb-host,vendorid=0x1546,productid=0x01a9"
             ]; # microvm.qemu.extraArgs
-            volumes = [{
-              image = "/var/tmp/dockervm.img";
-              mountPoint = "/var/lib/docker";
-              size = 51200;
-              autoCreate = true;
-              fsType = "ext4";
-            }];# microvm.volumes
+            volumes = [
+              {
+                image = "/var/tmp/dockervm_internal.img";
+                mountPoint = "/var/lib/internal";
+                size = 10240;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+              {
+                image = "/var/tmp/dockervm.img";
+                mountPoint = "/var/lib/docker";
+                size = 51200;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+            ];# microvm.volumes
             shares = [
+              {
+                source = "/var/vms_shares/common";
+                mountPoint = "/var/vms_share/common";
+                tag = "common_share_dockervm";
+                proto = "virtiofs";
+                socket = "common_share_dockervm.sock";
+              }
+              {
+                source = "/var/vms_shares/dockervm";
+                mountPoint = "/var/vms_share/host";
+                tag = "dockervm_share";
+                proto = "virtiofs";
+                socket = "dockervm_share.sock";
+              }
               {
                 source = "/var/fogdata";
                 mountPoint = "/var/lib/fogdata";


### PR DESCRIPTION
- One storage common for all VMs:
	- /var/vms_shares/common
- One persistence storage dedicated only for every VM:
	- /var/lib/internal - for dockervm
	- /var/lib/internal - for netvm
- One storage common for VM and Host:
	- /var/vms_shares/dockervm -> /var/vms_shares/host
	- /var/vms_shares/netvm -> /var/vms_shares/host