### PR TITLE
FMO-21: Persistence storage for VMs, and file transfer

### DIFF
--- a/hardware/fmo-os-rugged-laptop-7330.nix
+++ b/hardware/fmo-os-rugged-laptop-7330.nix
@@ -179,7 +179,31 @@
               }
             ]; # microvm.devices
 
+            volumes = [
+              {
+                image = "/var/tmp/netvm_internal.img";
+                mountPoint = "/var/lib/internal";
+                size = 10240;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+            ];# microvm.volumes
+
             shares = [
+              {
+                source = "/var/vms_shares/common";
+                mountPoint = "/var/vms_share/common";
+                tag = "common_share_netvm";
+                proto = "virtiofs";
+                socket = "common_share_netvm.sock";
+              }
+              {
+                source = "/var/vms_shares/netvm";
+                mountPoint = "/var/vms_share/host";
+                tag = "netvm_share";
+                proto = "virtiofs";
+                socket = "netvm_share.sock";
+              }
               {
                 source = "/var/netvm/netconf";
                 mountPoint = "/etc/NetworkManager/system-connections";
@@ -225,14 +249,37 @@
                 path = "vendorid=0x1546,productid=0x01a9";
               }
             ]; # microvm.devices
-            volumes = [{
-              image = "/var/tmp/dockervm.img";
-              mountPoint = "/var/lib/docker";
-              size = 51200;
-              autoCreate = true;
-              fsType = "ext4";
-            }];# microvm.volumes
+            volumes = [
+              {
+                image = "/var/tmp/dockervm_internal.img";
+                mountPoint = "/var/lib/internal";
+                size = 10240;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+              {
+                image = "/var/tmp/dockervm.img";
+                mountPoint = "/var/lib/docker";
+                size = 51200;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+            ];# microvm.volumes
             shares = [
+              {
+                source = "/var/vms_shares/common";
+                mountPoint = "/var/vms_share/common";
+                tag = "common_share_dockervm";
+                proto = "virtiofs";
+                socket = "common_share_dockervm.sock";
+              }
+              {
+                source = "/var/vms_shares/dockervm";
+                mountPoint = "/var/vms_share/host";
+                tag = "dockervm_share";
+                proto = "virtiofs";
+                socket = "dockervm_share.sock";
+              }
               {
                 source = "/var/fogdata";
                 mountPoint = "/var/lib/fogdata";

--- a/hardware/fmo-os-rugged-tablet-7230.nix
+++ b/hardware/fmo-os-rugged-tablet-7230.nix
@@ -158,7 +158,32 @@
                 path = "vendorid=0x0525,productid=0xa4a2";
               }
             ]; # microvm.devices
+
+            volumes = [
+              {
+                image = "/var/tmp/netvm_internal.img";
+                mountPoint = "/var/lib/internal";
+                size = 10240;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+            ];# microvm.volumes
+
             shares = [
+              {
+                source = "/var/vms_shares/common";
+                mountPoint = "/var/vms_share/common";
+                tag = "common_share_netvm";
+                proto = "virtiofs";
+                socket = "common_share_netvm.sock";
+              }
+              {
+                source = "/var/vms_shares/netvm";
+                mountPoint = "/var/vms_share/host";
+                tag = "netvm_share";
+                proto = "virtiofs";
+                socket = "netvm_share.sock";
+              }
               {
                 source = "/var/netvm/netconf";
                 mountPoint = "/etc/NetworkManager/system-connections";
@@ -204,14 +229,38 @@
                 path = "vendorid=0x1546,productid=0x01a9";
               }
             ]; # microvm.devices
-            volumes = [{
-              image = "/var/tmp/dockervm.img";
-              mountPoint = "/var/lib/docker";
-              size = 51200;
-              autoCreate = true;
-              fsType = "ext4";
-            }];# microvm.volumes
+            volumes = [
+              {
+                image = "/var/tmp/dockervm_internal.img";
+                mountPoint = "/var/lib/internal";
+                size = 10240;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+              {
+                image = "/var/tmp/dockervm.img";
+                mountPoint = "/var/lib/docker";
+                size = 51200;
+                autoCreate = true;
+                fsType = "ext4";
+              }
+            ];# microvm.volumes
+
             shares = [
+              {
+                source = "/var/vms_shares/common";
+                mountPoint = "/var/vms_share/common";
+                tag = "common_share_dockervm";
+                proto = "virtiofs";
+                socket = "common_share_dockervm.sock";
+              }
+              {
+                source = "/var/vms_shares/dockervm";
+                mountPoint = "/var/vms_share/host";
+                tag = "dockervm_share";
+                proto = "virtiofs";
+                socket = "dockervm_share.sock";
+              }
               {
                 source = "/var/fogdata";
                 mountPoint = "/var/lib/fogdata";


### PR DESCRIPTION
- One storage common for all VMs:
	- /var/vms_shares/common
- One persistence storage dedicated only for every VM:
	- /var/lib/internal - for dockervm
	- /var/lib/internal - for netvm
- One storage common for VM and Host:
	- /var/vms_shares/dockervm -> /var/vms_shares/host
	- /var/vms_shares/netvm -> /var/vms_shares/host