### PR TITLE
FMO-53: Fix no wifi detected in netvm due to conflicted config

### DIFF
--- a/hardware/fmo-os-rugged-laptop-7330.nix
+++ b/hardware/fmo-os-rugged-laptop-7330.nix
@@ -91,9 +91,6 @@
               enable = true;
               internalIPs = [ "192.168.101.0/24" ];
             }; # networking.nat
-            wireless = {
-              enable = true;
-            };
             networkmanager = {
               enable = true;
               unmanaged = [

--- a/hardware/fmo-os-rugged-tablet-7230.nix
+++ b/hardware/fmo-os-rugged-tablet-7230.nix
@@ -91,9 +91,6 @@
               enable = true;
               internalIPs = [ "192.168.101.0/24" ];
             }; # networking.nat
-            wireless = {
-              enable = true;
-            };
             networkmanager = {
               enable = true;
               unmanaged = [


### PR DESCRIPTION
- Only networking.wireless or networking.networkmanager can be enabled at a time