### PR TITLE
FMO-62 with other GH actions updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,8 @@ name: build
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]*'
+      - "v[0-9]+.[0-9]+.[0-9]*"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -24,16 +25,47 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: Extract tag version
-        id: tag
-        run: echo "TAG_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fetch-depth: 0
+      - name: Generate FMO build version
+        id: fmo-build-version
+        shell: bash
+        run: |
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          REF="${{ github.ref }}"
+          REF_TYPE="${{ github.ref_type }}"
+          REF_NAME="${{ github.ref_name }}"
+
+          # Set default to "git-<short-sha>"
+          FMO_BUILD_VERSION="git-$SHORT_SHA"
+
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            FMO_BUILD_VERSION="$REF_NAME"
+          elif [[ "$REF_TYPE" == "branch" ]]; then
+            # Check if there's a reachable tag on the branch
+            if git name-rev --name-only --tags --no-undefined "$REF" 2>/dev/null; then
+              # Format: <tag-name>-<#-of-commits-since-tag>-<abbrev-hash>
+              FMO_BUILD_VERSION="$(git describe --tags --abbrev=7 "$REF")"
+            else
+              # No reachable parent tag on branch
+              FMO_BUILD_VERSION="$REF_NAME-g$SHORT_SHA"
+            fi
+          fi
+
+          echo "SHA:           $SHA"
+          echo "SHORT_SHA:     $SHORT_SHA"
+          echo "REF:           $REF"
+          echo "REF_TYPE:      $REF_TYPE"
+          echo "REF_NAME:      $REF_NAME"
+          echo "FMO_BUILD_VERSION: $FMO_BUILD_VERSION"
+          echo "FMO_BUILD_VERSION=$FMO_BUILD_VERSION" >> "$GITHUB_OUTPUT"
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
-          tool-cache: false
-        
+          tool-cache: true
+
           # all of these default to true, but feel free to set to
           # "false" if necessary for your workflow
           android: true
@@ -42,27 +74,77 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
+      - name: Install Nix
+        id: install-nix
+        uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            substitute = true
+            always-allow-substitutes = true
+            substituters = https://cache.nixos.org https://nixpkgs.cachix.org https://nixpkgs-unfree.cachix.org https://nix-community.cachix.org
+            trusted-substituters = https://cache.nixos.org https://nixpkgs.cachix.org https://nixpkgs-unfree.cachix.org https://nix-community.cachix.org
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nixpkgs.cachix.org-1:q91R6hxbwFvDqTSDKwDAV4T5PxqXGxswD8vhONFMeOE= nixpkgs-unfree.cachix.org-1:hqvoInulhbV4nJ9yJOEr+4wxhDV4xq2d1DK7S6Nj6rs= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+      - name: Setup Cachix
+        id: setup-cachix
+        uses: cachix/cachix-action@v15
+        with:
+          name: fmo-os
+          authToken: "${{ secrets.CACHIX_TOKEN }}"
+      - name: Prepare build environment
+        id: prepare-build
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          SSH_DIR=$HOME/.ssh
+
+          mkdir -p $SSH_DIR
+          chmod 0700 $SSH_DIR
+
+          ssh-keyscan -t ed25519 -H github.com > $SSH_DIR/known_hosts
+          chmod 600 $SSH_DIR/known_hosts
+
+          echo "${{ secrets.RA_TOKEN }}" > $SSH_DIR/id_rsa
+          chmod 600 $SSH_DIR/id_rsa
+
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add $SSH_DIR/id_rsa
+
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
       - name: Build
         id: build
-        uses: ./.github/actions/build-action
-        with:
-          build_target: 'fmo-os-installer-debug'
-          CACHIX_TOKEN: ${{ secrets.CACHIX_TOKEN }}
-          RA_TOKEN: ${{ secrets.RA_TOKEN }}
+        env:
+          FMO_BUILD_VERSION: "${{ steps.fmo-build-version.outputs.FMO_BUILD_VERSION }}"
+        run: |
+          nix flake show
+          cachix watch-exec fmo-os -- nix build -L --accept-flake-config .#fmo-os-installer-debug
+
+          res="$(readlink -f ./result/iso/nixos.iso)"
+          if ! [[ -f "${res}" ]]; then
+            echo "No result found, build failed!" >&2
+            exit 1
+          fi
+          echo "Result image: $res"
+
+          mkdir -p ./out
+          cp -v "${res}" ./out/nixos.iso
+          output="$(ls ./out/nixos.iso)"
+          echo "Output: $output"
+          echo "OUTPUT_IMAGE=$output" >> "$GITHUB_OUTPUT"
       - name: Push to JFrog artifactory
         uses: ./.github/actions/upload-action-jfrog
         with:
           JFROG_UNAME: ${{ secrets.JFROG_UNAME }}
           JFROG_TOKEN: ${{ secrets.JFROG_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}
-          input-paths:  |
-            ${{ steps.build.outputs.outimg }}:tii-fmo-os/releases/FMO-OS_inst_${{ steps.tag.outputs.TAG_VERSION }}.iso
+          input-paths: |
+            ${{ steps.build.outputs.OUTPUT_IMAGE }}:tii-fmo-os/releases/FMO-OS_inst_${{ steps.fmo-build-version.outputs.FMO_BUILD_VERSION }}.iso
       - name: Push to Harbor artifactory
         uses: ./.github/actions/upload-action-harbor
         with:
           HARBOR_UNAME: ${{ secrets.HARBOR_UNAME }}
           HARBOR_TOKEN: ${{ secrets.HARBOR_TOKEN }}
           HARBOR_URL: ${{ secrets.HARBOR_URL }}
-          input-paths:  |
-            ${{ steps.build.outputs.outimg }}:fmo/pmc-installer:${{ steps.tag.outputs.TAG_VERSION }}
-
+          input-paths: |
+            ${{ steps.build.outputs.OUTPUT_IMAGE }}:fmo/pmc-installer:${{ steps.fmo-build-version.outputs.FMO_BUILD_VERSION }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install nix
-        uses: cachix/install-nix-action@v24
+        uses: cachix/install-nix-action@v30
       - name: Check .nix formatting
         run: nix fmt -- --fail-on-change || echo "::error::nix fmt fails"
       - name: Check reuse lint

--- a/hardware/fmo-os-rugged-devices.nix
+++ b/hardware/fmo-os-rugged-devices.nix
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # fmo-os-rugged-devices computer -target
-{
+let 
+  buildVersion = builtins.getEnv("FMO_BUILD_VERSION");
+in {
   sysconf = {
     name = "fmo-os-rugged-devices";
     ipaddr = "192.168.101.2";
     defaultgw = "192.168.101.1";
-    release = "v1.1.0a";
+    release = if buildVersion != ""
+              then buildVersion
+              else "v1.1.0a";
 
     fmo-system = {
       RAversion = "v0.8.4";


### PR DESCRIPTION
This PR generates the SW version tag during build
[FMO-62](https://jira.tii.ae/browse/FMO-62)

Other updates:

- Update `check.yml` action to use the latest `nix-install-action`
- Use `nix-install-action` and `cachix-action` to handle Nix/Cachix install
- Build the image directly on the runner action instead of separate Docker container


