### PR TITLE
FMO-92: fmo-tool, add ability to passthrough with vendorid and regex-productid

### DIFF
--- a/hardware/fmo-os-rugged-laptop-7330.nix
+++ b/hardware/fmo-os-rugged-laptop-7330.nix
@@ -397,6 +397,11 @@
                   vendorid = "1546";
                   productid = "01a9";
                 }
+                {
+                  bus = "usb";
+                  vendorid = "1050";
+                  productid = ".*";
+                }
               ];
             }; # services.fmo-dynamic-device-passthrough
             fmo-dci = {

--- a/hardware/fmo-os-rugged-tablet-7230.nix
+++ b/hardware/fmo-os-rugged-tablet-7230.nix
@@ -377,6 +377,11 @@
                   vendorid = "1546";
                   productid = "01a9";
                 }
+                {
+                  bus = "usb";
+                  vendorid = "1050";
+                  productid = ".*";
+                }
               ];
             }; # services.fmo-dynamic-device-passthrough
             fmo-dci = {

--- a/modules/custom-packages/fmo-tool/fmo-tool.nix
+++ b/modules/custom-packages/fmo-tool/fmo-tool.nix
@@ -43,7 +43,7 @@ pkgs.python3Packages.buildPythonApplication {
 
   src = builtins.fetchGit {
     url = "git@github.com:tiiuae/fmo-tool.git";
-    rev = "4cdb772a104893ecf2d15333bad0f335040c3be9";
+    rev = "ed1ba0debd766a07efb14b59401d9ae8b2c5093e";
     ref = "refs/heads/main";
   };
 }

--- a/modules/custom-packages/vhotplug/vendorid.patch
+++ b/modules/custom-packages/vhotplug/vendorid.patch
@@ -1,0 +1,13 @@
+diff --git a/vhotplug/config.py b/vhotplug/config.py
+index 689d243..c1e7300 100644
+--- a/vhotplug/config.py
++++ b/vhotplug/config.py
+@@ -32,7 +32,7 @@ class Config:
+                     logger.debug(f"Rule {usb_description}")
+                     logger.debug(f"Checking {vid}:{pid} against {usb_vid}:{usb_pid}")
+                     vidMatch = usb_vid and vid.casefold() == usb_vid.casefold()
+-                    pidMatch = usb_pid and pid.casefold() == usb_pid.casefold()
++                    pidMatch = (usb_pid and pid.casefold() == usb_pid.casefold()) or re.match(usb_pid, pid, re.IGNORECASE)
+                     if vidMatch and pidMatch:
+                         logger.info(f"Found VM {vm_name} by vendor id / product id, description: {usb_description}")
+                         matches = True

--- a/modules/custom-packages/vhotplug/vhotplug.nix
+++ b/modules/custom-packages/vhotplug/vhotplug.nix
@@ -19,6 +19,8 @@ in
 
     doCheck = false;
 
+    patches = [ ./vendorid.patch ];
+
     src = fetchFromGitHub {
       owner = "tiiuae";
       repo = "vhotplug";


### PR DESCRIPTION
- Allow passthrough device with exactly-matched vendorid and regex-matched productid
- Update fmo-tool version with vendorname in ddp, allow passthrough device with vendorname using fmo-tool option -vn
- Add default passthrough for device with vendorid "1050"